### PR TITLE
Migration to pipenv instead of pip

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,15 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+numpy = ">=1.24.0"
+astropy = ">=5.1"
+Pillow = ">=9.5"
+xisf = {git = "https://github.com/sergio-dr/xisf.git"}
+
+[dev-packages]
+
+[requires]
+python_version = "3" 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,20 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {},
+    "develop": {}
+} 

--- a/README.md
+++ b/README.md
@@ -25,22 +25,32 @@ A simple Python script to recursively scan your astrophotography library, conver
 
 ## Installation
 
+### Prerequisites
+
+Make sure you have Python 3+ and pipenv installed:
+
+> **Note**: For detailed installation instructions and troubleshooting for pipenv, see the [official Pipenv installation guide](https://pipenv.pypa.io/en/latest/installation.html).
+
+### Setup
+
 1. Clone the repo:
 
    ```bash
    git clone https://github.com/yourname/fits-to-xisf.git
    cd fits-to-xisf
    ```
+
 2. Copy and edit the config template:
 
    ```bash
    cp config.ini.example config.ini
    # then adjust paths and settings in config.ini
    ```
-3. Install dependencies:
+
+3. Install dependencies with pipenv:
 
    ```bash
-   pip install -r requirements.txt
+   pipenv install
    ```
 
 ## Usage
@@ -48,6 +58,11 @@ A simple Python script to recursively scan your astrophotography library, conver
 Run the script without arguments (reads `config.ini`):
 
 ```bash
+# Using pipenv
+pipenv run python fits_to_xisf_batch.py
+
+# Or activate the virtual environment first
+pipenv shell
 python fits_to_xisf_batch.py
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-numpy>=1.24.0
-astropy>=5.1
-Pillow>=9.5
-xisf @ git+https://github.com/sergio-dr/xisf.git@<commit-ish>


### PR DESCRIPTION
Enhance README.md with installation prerequisites and updated setup instructions using pipenv.

I prefer PIpenv instead of pip ( need a specific install), as you don't have confilcts with dependencies.
Feel free to merge it if you want :)